### PR TITLE
Fixes for RSU + colorizer

### DIFF
--- a/ginnoptimizer.py
+++ b/ginnoptimizer.py
@@ -148,9 +148,9 @@ def enable_rsu():
     """
     print_color('+', 'Enabling RSU mode')
     print ''
-    check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_OSU_method";',
+    check_and_set_param('SHOW VARIABLES LIKE "wsrep_OSU_method";',
                         'wsrep_OSU_method', 'RSU',
-                        'SET GLOBAL wsrep_OSU_method="RSU";')
+                        'SET wsrep_OSU_method="RSU";')
     check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_desync";',
                         'wsrep_desync', 'ON', 'SET GLOBAL wsrep_desync=1;')
     print_color('ok')
@@ -166,9 +166,9 @@ def restore_toi():
                         'wsrep_on', 'ON', 'SET GLOBAL wsrep_on=ON;')
     check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_desync";',
                         'wsrep_desync', 'OFF', 'SET GLOBAL wsrep_desync=0;')
-    check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_OSU_method";',
+    check_and_set_param('SHOW VARIABLES LIKE "wsrep_OSU_method";',
                         'wsrep_OSU_method', 'TOI',
-                        'SET GLOBAL wsrep_OSU_method="TOI";')
+                        'SET wsrep_OSU_method="TOI";')
     print_color('ok')
 
 

--- a/ginnoptimizer.py
+++ b/ginnoptimizer.py
@@ -52,7 +52,7 @@ def print_color(mtype, message=''):
 
     """
 
-    init(autoreset=True)
+    init(autoreset=False)
     if (mtype == 'ok'):
         print(Fore.GREEN + 'OK' + Fore.RESET + message)
     elif (mtype == '+'):

--- a/ginnoptimizer.py
+++ b/ginnoptimizer.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 # encoding: utf-8
 # Made by Pierre Mavro / Deimosfr

--- a/ginnoptimizer.py
+++ b/ginnoptimizer.py
@@ -151,8 +151,6 @@ def enable_rsu():
     check_and_set_param('SHOW VARIABLES LIKE "wsrep_OSU_method";',
                         'wsrep_OSU_method', 'RSU',
                         'SET wsrep_OSU_method="RSU";')
-    check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_desync";',
-                        'wsrep_desync', 'ON', 'SET GLOBAL wsrep_desync=1;')
     print_color('ok')
 
 
@@ -164,8 +162,6 @@ def restore_toi():
     print ''
     check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_on";',
                         'wsrep_on', 'ON', 'SET GLOBAL wsrep_on=ON;')
-    check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_desync";',
-                        'wsrep_desync', 'OFF', 'SET GLOBAL wsrep_desync=0;')
     check_and_set_param('SHOW VARIABLES LIKE "wsrep_OSU_method";',
                         'wsrep_OSU_method', 'TOI',
                         'SET wsrep_OSU_method="TOI";')
@@ -365,8 +361,6 @@ def check_galera_current_state():
                 'ON', 'Galera node is not connected')
 
     # Optional but required checks
-    check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_desync";',
-                        'wsrep_desync', 'OFF', 'SET GLOBAL wsrep_desync=0;')
     check_and_set_param('SHOW GLOBAL VARIABLES LIKE "wsrep_OSU_method";',
                         'wsrep_OSU_method', 'TOI',
                         'SET GLOBAL wsrep_OSU_method="TOI";')


### PR DESCRIPTION
wsrep_OSU_method is now a session variable (has been for a long time...) so it's recommended to use that over the global change, as it's much more flexible. It also means that desyncing the node ahead is not needed anymore - Galera takes care of desyncing the node during RSU.

Also I removed the autorefresh in the colorizer. It causes horrible things, stalling or slowing down the script among others (2hrs vs 17mn!) and I wonder if the person who coded that lib really knew what he was doing... Just strace the process to see what I mean.

Thanks!
